### PR TITLE
fix: change cognitoUserPoolEvent version from number to string

### DIFF
--- a/lib/events/aws/cognito-user-pool-event-template.json
+++ b/lib/events/aws/cognito-user-pool-event-template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": "2",
   "triggerSource": "string",
   "region": "us-east-1",
   "userPoolId": "abcd123",


### PR DESCRIPTION
The version value should be a string.

Sorry, I only have the Go docs for reference https://godoc.org/github.com/aws/aws-lambda-go/events#CognitoEventUserPoolsHeader

Also, this may be the smallest PR in the history of GitHub.